### PR TITLE
feat: send X-Content-Type-Options: nosniff on all responses

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ tower-http = { version = "0.6.2", features = [
     "compression-gzip",
     "cors",
     "trace",
+    "set-header",
 ] }
 tracing = "0.1.41"
 tracing-subscriber = { version = "=0.3.19", features = ["time"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ pub mod frontend;
 pub mod resource;
 
 use api::get_api_router;
+use axum::http::{HeaderValue, header::X_CONTENT_TYPE_OPTIONS};
 use clap::Parser;
 use config::Config;
 use console::style;
@@ -18,6 +19,7 @@ use tower::ServiceBuilder;
 use tower_http::{
     compression::CompressionLayer,
     cors::{Any, CorsLayer},
+    set_header::SetResponseHeaderLayer,
     trace::TraceLayer,
 };
 use tracing::{error, info};
@@ -68,7 +70,11 @@ async fn main() {
         .layer(
             ServiceBuilder::new()
                 .layer(TraceLayer::new_for_http())
-                .layer(CorsLayer::new().allow_origin(Any)),
+                .layer(CorsLayer::new().allow_origin(Any))
+                .layer(SetResponseHeaderLayer::overriding(
+                    X_CONTENT_TYPE_OPTIONS,
+                    HeaderValue::from_static("nosniff"),
+                )),
         );
 
     let port = config.port;


### PR DESCRIPTION
## What

Adds `X-Content-Type-Options: nosniff` to every response via a `SetResponseHeaderLayer` on the outer service stack.

## Why

Files served under `/resource` are archived from third-party platforms. Without `nosniff`, a browser may MIME-sniff such a file into an executable type (e.g. HTML/JS), turning archived content into an execution vector. This header is cheap, has no downside on localhost, and becomes meaningful if the viewer is ever exposed beyond localhost.

This is the only header from #24 worth adding under the project's actual threat model: the content-level XSS root cause is fixed separately (#27, DOMPurify), and clickjacking / full CSP add little value for a mostly-localhost, read-only viewer.

Verified locally — `x-content-type-options: nosniff` is present on `/api` and `/resource` responses.

Refs #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)